### PR TITLE
Fix Netlify build error: remove extra quote in netlify.toml publish path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 command = "next build"
-publish = ".next""
+publish = ".next"
 
 [build.environment]
   PRISMA_GENERATE_DATAPROXY = "true"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove extra quote from netlify.toml publish path

- Fixes Netlify build configuration syntax error


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["netlify.toml<br/>publish path"] -- "remove extra quote" --> B["Valid configuration<br/>publish = .next"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>netlify.toml</strong><dd><code>Remove extra quote from publish path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

netlify.toml

<ul><li>Removed extra trailing quote from <code>publish</code> field value<br> <li> Changed <code>publish = ".next""</code> to <code>publish = ".next"</code><br> <li> Fixes invalid TOML syntax that was causing Netlify build failures</ul>


</details>


  </td>
  <td><a href="https://github.com/YuShato/next-fast-table/pull/79/files#diff-ab8f79b68b7adff7a07db953bf453f3c5aa6ade98d2b1b67d8432b36392489ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

